### PR TITLE
Resimulate by child events

### DIFF
--- a/src/file/write_sim_files.jl
+++ b/src/file/write_sim_files.jl
@@ -104,7 +104,7 @@ function openOutputFiles!(sim::Simulation)
 		
 		# write events table name and header
 		writeDlmLine!(sim.eventsFileIO, "events")
-		writeDlmLine!(sim.eventsFileIO, "time", "eventKey", "ambIndex", "callIndex", "stationIndex")
+		writeDlmLine!(sim.eventsFileIO, "index", "parentIndex", "time", "eventKey", "ambIndex", "callIndex", "stationIndex")
 	end
 end
 
@@ -126,9 +126,8 @@ function writeEventToFile!(sim::Simulation, event::Event)
 		stationIndex = sim.ambulances[event.ambIndex].stationIndex
 	end
 	
-	writeDlmLine!(sim.eventsFileIO, @sprintf("%0.5f", event.time), Int(event.form),
-		event.ambIndex, event.callIndex, stationIndex)
-		
+	writeDlmLine!(sim.eventsFileIO, event.index, event.parentIndex, @sprintf("%0.5f", event.time), Int(event.form), event.ambIndex, event.callIndex, stationIndex)
+	
 	# flush(sim.eventsFileIO)
 end
 

--- a/src/types/event.jl
+++ b/src/types/event.jl
@@ -1,9 +1,9 @@
 # add new event to list, maintain sorting by time
 function addEvent!(eventList::Vector{Event};
-	form::EventForm = nullEvent, time::Float = nullTime, ambulance::Ambulance = Ambulance(), call::Call = Call(),
-	addEventToAmb::Bool = true)
+	parentEvent::Event = Event(), form::EventForm = nullEvent, time::Float = nullTime, ambulance::Ambulance = Ambulance(), call::Call = Call(), addEventToAmb::Bool = true)
 	
 	event = Event()
+	event.parentIndex = parentEvent.index
 	event.form = form
 	event.time = time
 	event.ambIndex = ambulance.index

--- a/src/types/types.jl
+++ b/src/types/types.jl
@@ -185,13 +185,16 @@ type Route
 end
 
 type Event
+	index::Int # index of event in list of events that have occurred (not for sim.eventList)
+	parentIndex::Int # index of parent event
 	form::EventForm # "type" is taken
 	time::Float
 	ambIndex::Int
 	callIndex::Int
 	stationIndex::Int # for now, only use this for resimulation, otherwise use ambulances[ambIndex].stationIndex
 	
-	Event() = new(nullEvent, nullTime, nullIndex, nullIndex, nullIndex)
+	
+	Event() = new(nullIndex, nullIndex, nullEvent, nullTime, nullIndex, nullIndex, nullIndex)
 end
 
 type Ambulance
@@ -517,10 +520,11 @@ type Resimulation
 	timeTolerance::Float
 	
 	events::Vector{Event}
+	eventsChildren::Vector{Vector{Event}} # eventsChildren[i] gives events that are children of event i
 	prevEventIndex::Int # index of previous event in events field
 	
 	Resimulation() = new(false, 0.0,
-		[], nullIndex)
+		[], [], nullIndex)
 end
 
 type Simulation
@@ -539,7 +543,8 @@ type Simulation
 	hospitals::Vector{Hospital}
 	stations::Vector{Station}
 	
-	eventList::Vector{Event}
+	eventList::Vector{Event} # events to occur now or in future
+	eventIndex::Int # index of event in events that have occurred
 	queuedCallList::Vector{Call} # keep track of queued calls. Calls can be queued after call arrivalTime + dispatchDelay
 	
 	resim::Resimulation
@@ -574,7 +579,7 @@ type Simulation
 	Simulation() = new(nullTime, nullTime, nullTime,
 		Network(), Travel(), Map(), Grid(),
 		[], [], [], [],
-		[], [],
+		[], 0, [],
 		Resimulation(),
 		nullFunction, nullFunction, MoveUpData(),
 		[],


### PR DESCRIPTION
Fields `index` and `parentIndex` added to event type, added these to
events file input and output, old events files will no longer work.
Changed function logic of `resimFindAmbToDispatch` and `resimMoveUp` to
work with parent/children event data.